### PR TITLE
Remove Docker-in-Docker feature

### DIFF
--- a/src/azure-functions-python/.devcontainer/devcontainer.json
+++ b/src/azure-functions-python/.devcontainer/devcontainer.json
@@ -13,14 +13,12 @@
     "onAutoForward": "ignore"
   },
   "features": {
-    "ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {},
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    "ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {}
   },
   "customizations": {
     "vscode": {
       "extensions": [
         "ms-azuretools.vscode-azurefunctions",
-        "ms-azuretools.vscode-docker",
         "ms-python.python"
       ]
     }


### PR DESCRIPTION
This pull request includes a small change to the `src/azure-functions-python/.devcontainer/devcontainer.json` file. The change removes the Docker-in-Docker feature and the Docker extension from the devcontainer configuration.

Changes in devcontainer configuration:

* Removed the `ghcr.io/devcontainers/features/docker-in-docker:2` feature.
* Removed the `ms-azuretools.vscode-docker` extension.