### PR TITLE
Add Azure Functions CLI version option

### DIFF
--- a/src/azure-functions-dotnet/.devcontainer/devcontainer.json
+++ b/src/azure-functions-dotnet/.devcontainer/devcontainer.json
@@ -13,7 +13,9 @@
     "onAutoForward": "ignore"
   },
   "features": {
-    "ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {}
+    "ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {
+      "version": "${templateOption:azureFunctionsCliVersion}"
+    }
   },
   "customizations": {
     "vscode": {

--- a/src/azure-functions-dotnet/devcontainer-template.json
+++ b/src/azure-functions-dotnet/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-dotnet",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "name": "Azure Functions (.NET)",
   "description": "Develop C# and .NET based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-dotnet",

--- a/src/azure-functions-dotnet/devcontainer-template.json
+++ b/src/azure-functions-dotnet/devcontainer-template.json
@@ -15,6 +15,19 @@
         "8.0-bookworm"
       ],
       "default": "8.0-bookworm"
+    },
+    "azureFunctionsCliVersion": {
+      "type": "string",
+      "description": "Azure Functions Core Tools version:",
+      "proposals": [
+        "latest",
+        "4.2.2",
+        "4.2.1",
+        "4.1.2",
+        "4.1.1",
+        "4.1.0"
+      ],
+      "default": "latest"
     }
   },
   "platforms": [

--- a/src/azure-functions-java/.devcontainer/devcontainer.json
+++ b/src/azure-functions-java/.devcontainer/devcontainer.json
@@ -13,7 +13,9 @@
     "onAutoForward": "ignore"
   },
   "features": {
-    "ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {},
+    "ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {
+      "version": "${templateOption:azureFunctionsCliVersion}"
+    },
     "ghcr.io/devcontainers/features/java:1": {
       "version": "none",
       "installMaven": true

--- a/src/azure-functions-java/devcontainer-template.json
+++ b/src/azure-functions-java/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-java",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "name": "Azure Functions (Java)",
   "description": "Develop Java based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-java",

--- a/src/azure-functions-java/devcontainer-template.json
+++ b/src/azure-functions-java/devcontainer-template.json
@@ -17,6 +17,19 @@
         "8-bookworm"
       ],
       "default": "21-bookworm"
+    },
+    "azureFunctionsCliVersion": {
+      "type": "string",
+      "description": "Azure Functions Core Tools version:",
+      "proposals": [
+        "latest",
+        "4.2.2",
+        "4.2.1",
+        "4.1.2",
+        "4.1.1",
+        "4.1.0"
+      ],
+      "default": "latest"
     }
   },
   "platforms": [

--- a/src/azure-functions-node/.devcontainer/devcontainer.json
+++ b/src/azure-functions-node/.devcontainer/devcontainer.json
@@ -13,7 +13,9 @@
     "onAutoForward": "ignore"
   },
   "features": {
-    "ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {}
+    "ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {
+      "version": "${templateOption:azureFunctionsCliVersion}"
+    }
   },
   "customizations": {
     "vscode": {

--- a/src/azure-functions-node/devcontainer-template.json
+++ b/src/azure-functions-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-node",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "name": "Azure Functions (Node.js)",
   "description": "Develop JavaScript and TypeScript based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-node",

--- a/src/azure-functions-node/devcontainer-template.json
+++ b/src/azure-functions-node/devcontainer-template.json
@@ -15,6 +15,19 @@
         "20-bookworm"
       ],
       "default": "22-bookworm"
+    },
+    "azureFunctionsCliVersion": {
+      "type": "string",
+      "description": "Azure Functions Core Tools version:",
+      "proposals": [
+        "latest",
+        "4.2.2",
+        "4.2.1",
+        "4.1.2",
+        "4.1.1",
+        "4.1.0"
+      ],
+      "default": "latest"
     }
   },
   "platforms": [

--- a/src/azure-functions-powershell/.devcontainer/devcontainer.json
+++ b/src/azure-functions-powershell/.devcontainer/devcontainer.json
@@ -13,7 +13,9 @@
     "onAutoForward": "ignore"
   },
   "features": {
-    "ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {},
+    "ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {
+      "version": "${templateOption:azureFunctionsCliVersion}"
+    },
     "ghcr.io/devcontainers/features/powershell:1": {
       "version": "${templateOption:imageVariant}"
     }

--- a/src/azure-functions-powershell/devcontainer-template.json
+++ b/src/azure-functions-powershell/devcontainer-template.json
@@ -14,6 +14,19 @@
         "7.4"
       ],
       "default": "7.4"
+    },
+    "azureFunctionsCliVersion": {
+      "type": "string",
+      "description": "Azure Functions Core Tools version:",
+      "proposals": [
+        "latest",
+        "4.2.2",
+        "4.2.1",
+        "4.1.2",
+        "4.1.1",
+        "4.1.0"
+      ],
+      "default": "latest"
     }
   },
   "platforms": [

--- a/src/azure-functions-powershell/devcontainer-template.json
+++ b/src/azure-functions-powershell/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-powershell",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "name": "Azure Functions (PowerShell)",
   "description": "Develop PowerShell based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-powershell",

--- a/src/azure-functions-python/.devcontainer/devcontainer.json
+++ b/src/azure-functions-python/.devcontainer/devcontainer.json
@@ -13,7 +13,9 @@
     "onAutoForward": "ignore"
   },
   "features": {
-    "ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {}
+    "ghcr.io/jlaundry/devcontainer-features/azure-functions-core-tools:1": {
+      "version": "${templateOption:azureFunctionsCliVersion}"
+    }
   },
   "customizations": {
     "vscode": {

--- a/src/azure-functions-python/devcontainer-template.json
+++ b/src/azure-functions-python/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-python",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "name": "Azure Functions (Python)",
   "description": "Develop Python based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-python",

--- a/src/azure-functions-python/devcontainer-template.json
+++ b/src/azure-functions-python/devcontainer-template.json
@@ -18,6 +18,19 @@
         "3.9-bookworm"
       ],
       "default": "3.12-bookworm"
+    },
+    "azureFunctionsCliVersion": {
+      "type": "string",
+      "description": "Azure Functions Core Tools version:",
+      "proposals": [
+        "latest",
+        "4.2.2",
+        "4.2.1",
+        "4.1.2",
+        "4.1.1",
+        "4.1.0"
+      ],
+      "default": "latest"
     }
   },
   "platforms": [


### PR DESCRIPTION
This pull request adds support for specifying the Azure Functions Core Tools version in all Azure Functions devcontainer templates (for .NET, Java, Node.js, PowerShell, and Python). This makes it easier for users to select and manage the CLI version used in their development containers, improving flexibility and compatibility. Additionally, each template's version number has been incremented to reflect this update.

**Azure Functions Core Tools version selection:**

* Added a new `azureFunctionsCliVersion` template option to all devcontainer templates (`devcontainer-template.json` files), allowing users to choose from several versions or use `latest` by default. [[1]](diffhunk://#diff-dcd2a8c84d4e00b972d8f321c2e2b78dc60b8aa566aaa291fda712eee9210f0dR18-R30) [[2]](diffhunk://#diff-7889cf2bea156e4e1a37949eb4ffc7dc922cb7bd8450c9807e3cb08985fede7bR20-R32) [[3]](diffhunk://#diff-b91473e4a6fc87d491598b481d2a6bdc620dbe2beff12cad67feee0e1613af40R18-R30) [[4]](diffhunk://#diff-74e3b2d1e1dc19d9470d3e5de414cd2df236bc0514dc80a9dc758319b197ec91R17-R29) [[5]](diffhunk://#diff-b132e108f0b40222561252e1e1ae03bb98c5597f465efb25d4889b6e430c2e90R21-R33)
* Updated the devcontainer feature configuration in all `.devcontainer/devcontainer.json` files to use the specified `azureFunctionsCliVersion` value when installing Azure Functions Core Tools. [[1]](diffhunk://#diff-b0657380a6db436d2b7b8c2e8f33300a1861a9719038fdff61fd5c372fd4ab5bL16-R18) [[2]](diffhunk://#diff-b263f11632259fa0267a233a98ffb426c4e0f26481d464341aee224599b7a672L16-R18) [[3]](diffhunk://#diff-094e3e13385d7a948bf87ce4df29d97bba4376659fab0f91a595aea9c2e452b6L16-R18) [[4]](diffhunk://#diff-b45ddc7d5aeb9f92f2b028b7896cdc801fe96a08f3782c9dba0880288c065ba2L16-R18) [[5]](diffhunk://#diff-d0c1e3a92358a4cfb463759b47cfb23ec0b0edb9ec0b7d06deacb6e3bf96739eL16-R18)

**Version bumps for templates:**

* Incremented the version number for each devcontainer template to reflect the new feature. [[1]](diffhunk://#diff-dcd2a8c84d4e00b972d8f321c2e2b78dc60b8aa566aaa291fda712eee9210f0dL3-R3) [[2]](diffhunk://#diff-7889cf2bea156e4e1a37949eb4ffc7dc922cb7bd8450c9807e3cb08985fede7bL3-R3) [[3]](diffhunk://#diff-b91473e4a6fc87d491598b481d2a6bdc620dbe2beff12cad67feee0e1613af40L3-R3) [[4]](diffhunk://#diff-74e3b2d1e1dc19d9470d3e5de414cd2df236bc0514dc80a9dc758319b197ec91L3-R3) [[5]](diffhunk://#diff-b132e108f0b40222561252e1e1ae03bb98c5597f465efb25d4889b6e430c2e90L3-R3)