### PR TITLE
Update Azure Functions devcontainer templates to include new version proposals for .NET, Node.js, and Python

### DIFF
--- a/src/azure-functions-dotnet/devcontainer-template.json
+++ b/src/azure-functions-dotnet/devcontainer-template.json
@@ -11,10 +11,11 @@
       "type": "string",
       "description": ".NET version:",
       "proposals": [
-        "9.0-bookworm",
-        "8.0-bookworm"
+        "10.0-noble",
+        "9.0-noble",
+        "8.0-noble"
       ],
-      "default": "8.0-bookworm"
+      "default": "8.0-noble"
     },
     "azureFunctionsCliVersion": {
       "type": "string",

--- a/src/azure-functions-node/devcontainer-template.json
+++ b/src/azure-functions-node/devcontainer-template.json
@@ -11,6 +11,7 @@
       "type": "string",
       "description": "Node.js version:",
       "proposals": [
+        "24-bookworm",
         "22-bookworm",
         "20-bookworm"
       ],

--- a/src/azure-functions-python/devcontainer-template.json
+++ b/src/azure-functions-python/devcontainer-template.json
@@ -17,7 +17,7 @@
         "3.11-bookworm",
         "3.10-bookworm"
       ],
-      "default": "3.13-bookworm"
+      "default": "3.12-bookworm"
     },
     "azureFunctionsCliVersion": {
       "type": "string",

--- a/src/azure-functions-python/devcontainer-template.json
+++ b/src/azure-functions-python/devcontainer-template.json
@@ -11,13 +11,13 @@
       "type": "string",
       "description": "Python version:",
       "proposals": [
+        "3.14-bookworm",
         "3.13-bookworm",
         "3.12-bookworm",
         "3.11-bookworm",
-        "3.10-bookworm",
-        "3.9-bookworm"
+        "3.10-bookworm"
       ],
-      "default": "3.12-bookworm"
+      "default": "3.13-bookworm"
     },
     "azureFunctionsCliVersion": {
       "type": "string",


### PR DESCRIPTION
This pull request updates the devcontainer templates for Azure Functions to include support for newer language versions and to update some default settings. The changes ensure that developers can use the latest available versions of .NET, Node.js, and Python when working with these templates.

Language version updates:

* .NET: Added support for `10.0-noble` and `9.0-noble`, removed `9.0-bookworm`, and updated the default version to `8.0-noble` in `src/azure-functions-dotnet/devcontainer-template.json`.
* Node.js: Added support for `24-bookworm` in `src/azure-functions-node/devcontainer-template.json`.
* Python: Added support for `3.14-bookworm`, removed `3.9-bookworm`, and updated the default version to `3.13-bookworm` in `src/azure-functions-python/devcontainer-template.json`.