### PR TITLE
Bump version to 2.0.0 and update Azure Functions CLI proposals to include 4.4.0 for all language templates

### DIFF
--- a/src/azure-functions-dotnet/devcontainer-template.json
+++ b/src/azure-functions-dotnet/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-dotnet",
-  "version": "1.1.7",
+  "version": "2.0.0",
   "name": "Azure Functions (.NET)",
   "description": "Develop C# and .NET based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-dotnet",
@@ -22,6 +22,7 @@
       "description": "Azure Functions CLI version:",
       "proposals": [
         "latest",
+        "4.4.0",
         "4.3.0",
         "4.2.2",
         "4.2.1"

--- a/src/azure-functions-java/devcontainer-template.json
+++ b/src/azure-functions-java/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-java",
-  "version": "1.1.6",
+  "version": "2.0.0",
   "name": "Azure Functions (Java)",
   "description": "Develop Java based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-java",
@@ -23,6 +23,7 @@
       "description": "Azure Functions CLI version:",
       "proposals": [
         "latest",
+        "4.4.0",
         "4.3.0",
         "4.2.2",
         "4.2.1"

--- a/src/azure-functions-node/devcontainer-template.json
+++ b/src/azure-functions-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-node",
-  "version": "1.1.7",
+  "version": "2.0.0",
   "name": "Azure Functions (Node.js)",
   "description": "Develop JavaScript and TypeScript based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-node",
@@ -22,6 +22,7 @@
       "description": "Azure Functions CLI version:",
       "proposals": [
         "latest",
+        "4.4.0",
         "4.3.0",
         "4.2.2",
         "4.2.1"

--- a/src/azure-functions-powershell/devcontainer-template.json
+++ b/src/azure-functions-powershell/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-powershell",
-  "version": "1.1.7",
+  "version": "2.0.0",
   "name": "Azure Functions (PowerShell)",
   "description": "Develop PowerShell based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-powershell",
@@ -20,6 +20,7 @@
       "description": "Azure Functions CLI version:",
       "proposals": [
         "latest",
+        "4.4.0",
         "4.3.0",
         "4.2.2",
         "4.2.1"

--- a/src/azure-functions-python/devcontainer-template.json
+++ b/src/azure-functions-python/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-python",
-  "version": "1.1.8",
+  "version": "2.0.0",
   "name": "Azure Functions (Python)",
   "description": "Develop Python based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-python",
@@ -24,6 +24,7 @@
       "description": "Azure Functions CLI version:",
       "proposals": [
         "latest",
+        "4.4.0",
         "4.3.0",
         "4.2.2",
         "4.2.1"


### PR DESCRIPTION
This pull request updates all Azure Functions devcontainer templates across supported languages. The main changes are a major version bump for each template and the addition of Azure Functions CLI version 4.4.0 as a selectable option.

Version updates:

* Bumped the `version` field to `2.0.0` in the following templates:
  - `azure-functions-dotnet` (`src/azure-functions-dotnet/devcontainer-template.json`)
  - `azure-functions-java` (`src/azure-functions-java/devcontainer-template.json`)
  - `azure-functions-node` (`src/azure-functions-node/devcontainer-template.json`)
  - `azure-functions-powershell` (`src/azure-functions-powershell/devcontainer-template.json`)
  - `azure-functions-python` (`src/azure-functions-python/devcontainer-template.json`)

CLI version options:

* Added `"4.4.0"` as an available proposal for the Azure Functions CLI version in each template:
  - `azure-functions-dotnet`
  - `azure-functions-java`
  - `azure-functions-node`
  - `azure-functions-powershell`
  - `azure-functions-python`