### PR TITLE
Update Azure Functions templates to version 2.0.2 and adjust README.md references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
           git config --global user.name github-actions[bot]
           git config pull.rebase false
 
+          # Replace 'blob/main' with 'blob/master' in generated README.md files
+          find src -name 'README.md' -exec sed -i 's|blob/main|blob/master|g' {} +
+
           branch=automated-documentation-update-$GITHUB_RUN_ID
           git checkout -b $branch
           message='Automated documentation update'

--- a/src/azure-functions-dotnet/devcontainer-template.json
+++ b/src/azure-functions-dotnet/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-dotnet",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "name": "Azure Functions (.NET)",
   "description": "Develop C# and .NET based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-dotnet",
@@ -15,13 +15,14 @@
         "9.0",
         "8.0"
       ],
-      "default": "8.0"
+      "default": "10.0"
     },
     "azureFunctionsCliVersion": {
       "type": "string",
       "description": "Azure Functions CLI version:",
       "proposals": [
         "latest",
+        "4.7.0",
         "4.6.0",
         "4.5.0",
         "4.4.0",

--- a/src/azure-functions-java/devcontainer-template.json
+++ b/src/azure-functions-java/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-java",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "name": "Azure Functions (Java)",
   "description": "Develop Java based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-java",
@@ -24,6 +24,7 @@
       "description": "Azure Functions CLI version:",
       "proposals": [
         "latest",
+        "4.7.0",
         "4.6.0",
         "4.5.0",
         "4.4.0",

--- a/src/azure-functions-node/devcontainer-template.json
+++ b/src/azure-functions-node/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-node",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "name": "Azure Functions (Node.js)",
   "description": "Develop JavaScript and TypeScript based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-node",
@@ -15,13 +15,14 @@
         "22",
         "20"
       ],
-      "default": "22"
+      "default": "24"
     },
     "azureFunctionsCliVersion": {
       "type": "string",
       "description": "Azure Functions CLI version:",
       "proposals": [
         "latest",
+        "4.7.0",
         "4.6.0",
         "4.5.0",
         "4.4.0",

--- a/src/azure-functions-powershell/devcontainer-template.json
+++ b/src/azure-functions-powershell/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-powershell",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "name": "Azure Functions (PowerShell)",
   "description": "Develop PowerShell based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-powershell",
@@ -20,6 +20,7 @@
       "description": "Azure Functions CLI version:",
       "proposals": [
         "latest",
+        "4.7.0",
         "4.6.0",
         "4.5.0",
         "4.4.0",

--- a/src/azure-functions-python/devcontainer-template.json
+++ b/src/azure-functions-python/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-python",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "name": "Azure Functions (Python)",
   "description": "Develop Python based Azure Functions. Includes all needed SDKs, extensions, and dependencies.",
   "documentationURL": "https://github.com/shibayan/devcontainers/tree/master/src/azure-functions-python",
@@ -24,6 +24,7 @@
       "description": "Azure Functions CLI version:",
       "proposals": [
         "latest",
+        "4.7.0",
         "4.6.0",
         "4.5.0",
         "4.4.0",

--- a/test/azure-functions-powershell/test.sh
+++ b/test/azure-functions-powershell/test.sh
@@ -3,7 +3,7 @@ cd $(dirname "$0")
 source test-utils.sh
 
 # Template specific tests
-check "powershell" pwsh  --version
+check "powershell" pwsh --version
 check "func" func --version
 
 # Report result


### PR DESCRIPTION
This pull request updates all Azure Functions devcontainer templates to version 2.0.2, sets newer default runtime versions, and adds Azure Functions CLI version 4.7.0 as a selectable option. Additionally, the release workflow now ensures that generated documentation links reference the correct branch.

**Devcontainer template updates:**

* Bumped version to `2.0.2` in all Azure Functions devcontainer templates: `.NET`, `Java`, `Node.js`, `PowerShell`, and `Python`. [[1]](diffhunk://#diff-dcd2a8c84d4e00b972d8f321c2e2b78dc60b8aa566aaa291fda712eee9210f0dL3-R3) [[2]](diffhunk://#diff-7889cf2bea156e4e1a37949eb4ffc7dc922cb7bd8450c9807e3cb08985fede7bL3-R3) [[3]](diffhunk://#diff-b91473e4a6fc87d491598b481d2a6bdc620dbe2beff12cad67feee0e1613af40L3-R3) [[4]](diffhunk://#diff-74e3b2d1e1dc19d9470d3e5de414cd2df236bc0514dc80a9dc758319b197ec91L3-R3) [[5]](diffhunk://#diff-b132e108f0b40222561252e1e1ae03bb98c5597f465efb25d4889b6e430c2e90L3-R3)
* Added `4.7.0` to the list of proposed `azureFunctionsCliVersion` options in all templates. [[1]](diffhunk://#diff-dcd2a8c84d4e00b972d8f321c2e2b78dc60b8aa566aaa291fda712eee9210f0dL18-R25) [[2]](diffhunk://#diff-7889cf2bea156e4e1a37949eb4ffc7dc922cb7bd8450c9807e3cb08985fede7bR27) [[3]](diffhunk://#diff-b91473e4a6fc87d491598b481d2a6bdc620dbe2beff12cad67feee0e1613af40L18-R25) [[4]](diffhunk://#diff-74e3b2d1e1dc19d9470d3e5de414cd2df236bc0514dc80a9dc758319b197ec91R23) [[5]](diffhunk://#diff-b132e108f0b40222561252e1e1ae03bb98c5597f465efb25d4889b6e430c2e90R27)

**Default runtime updates:**

* Changed default .NET runtime version to `10.0` in `azure-functions-dotnet` and Node.js runtime version to `24` in `azure-functions-node`. [[1]](diffhunk://#diff-dcd2a8c84d4e00b972d8f321c2e2b78dc60b8aa566aaa291fda712eee9210f0dL18-R25) [[2]](diffhunk://#diff-b91473e4a6fc87d491598b481d2a6bdc620dbe2beff12cad67feee0e1613af40L18-R25)

**Release workflow improvement:**

* Updated the GitHub Actions release workflow to replace `blob/main` with `blob/master` in generated `README.md` files to ensure correct documentation links.