### PR TITLE
Refactor smoke test scripts and consolidate template checks

### DIFF
--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -1,4 +1,5 @@
 name: 'Smoke test'
+description: 'Builds and smoke-tests a dev container template'
 inputs:
   template:
     description: 'Template to test'
@@ -7,10 +8,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout master
-      id: checkout_release
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
     - name: Build template
       id: build_template
       shell: bash

--- a/.github/actions/smoke-test/build.sh
+++ b/.github/actions/smoke-test/build.sh
@@ -13,7 +13,7 @@ pushd "${SRC_DIR}"
 # Configure templates only if `devcontainer-template.json` contains the `options` property.
 OPTION_PROPERTY=( $(jq -r '.options' devcontainer-template.json) )
 
-if [ "${OPTION_PROPERTY}" != "" ] && [ "${OPTION_PROPERTY}" != "null" ] ; then  
+if [ "${OPTION_PROPERTY}" != "" ] && [ "${OPTION_PROPERTY}" != "null" ] ; then
     OPTIONS=( $(jq -r '.options | keys[]' devcontainer-template.json) )
 
     if [ "${OPTIONS[0]}" != "" ] && [ "${OPTIONS[0]}" != "null" ] ; then
@@ -43,7 +43,7 @@ if [ -d "${TEST_DIR}" ] ; then
     DEST_DIR="${SRC_DIR}/test-project"
     mkdir -p ${DEST_DIR}
     cp -Rp ${TEST_DIR}/* ${DEST_DIR}
-    cp test/test-utils/test-utils.sh ${DEST_DIR}
+    cp test/test-utils/* ${DEST_DIR}
 fi
 
 export DOCKER_BUILDKIT=1

--- a/test/azure-functions-dotnet/test.sh
+++ b/test/azure-functions-dotnet/test.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
-cd $(dirname "$0")
-source test-utils.sh
+set -e
 
-# Template specific tests
-check "dotnet" dotnet --version
-check "func" func --version
-
-# Report result
-reportResults
+cd "$(dirname "$0")"
+bash run-template-checks.sh "dotnet" dotnet --version

--- a/test/azure-functions-java/test.sh
+++ b/test/azure-functions-java/test.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
-cd $(dirname "$0")
-source test-utils.sh
+set -e
 
-# Template specific tests
-check "java" java -version
-check "func" func --version
-
-# Report result
-reportResults
+cd "$(dirname "$0")"
+bash run-template-checks.sh "java" java -version

--- a/test/azure-functions-node/test.sh
+++ b/test/azure-functions-node/test.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
-cd $(dirname "$0")
-source test-utils.sh
+set -e
 
-# Template specific tests
-check "node" node --version
-check "func" func --version
-
-# Report result
-reportResults
+cd "$(dirname "$0")"
+bash run-template-checks.sh "node" node --version

--- a/test/azure-functions-powershell/test.sh
+++ b/test/azure-functions-powershell/test.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
-cd $(dirname "$0")
-source test-utils.sh
+set -e
 
-# Template specific tests
-check "powershell" pwsh --version
-check "func" func --version
-
-# Report result
-reportResults
+cd "$(dirname "$0")"
+bash run-template-checks.sh "powershell" pwsh --version

--- a/test/azure-functions-python/test.sh
+++ b/test/azure-functions-python/test.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
-cd $(dirname "$0")
-source test-utils.sh
+set -e
 
-# Template specific tests
-check "python" python --version
-check "func" func --version
-
-# Report result
-reportResults
+cd "$(dirname "$0")"
+bash run-template-checks.sh "python" python --version

--- a/test/test-utils/run-template-checks.sh
+++ b/test/test-utils/run-template-checks.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+source test-utils.sh
+
+LABEL="$1"
+shift
+
+check "$LABEL" "$@"
+check "func" func --version
+
+reportResults


### PR DESCRIPTION
This pull request refactors the smoke test scripts and supporting files to improve maintainability and consistency across template-specific tests. The main changes include consolidating test utility usage, updating test scripts to use a new helper, and minor improvements to the GitHub action configuration.

**Test script refactoring and consolidation:**
* Added a new helper script `run-template-checks.sh` to centralize common test logic, reducing duplication across all template-specific test scripts. Each test script now calls this helper instead of sourcing and manually invoking functions from `test-utils.sh`.
* Updated all template-specific test scripts (`test.sh` files for dotnet, java, node, powershell, python) to use the new helper script, simplifying their structure and ensuring consistent test execution. [[1]](diffhunk://#diff-1863e1aa2ee7bfcd6773a0e59c1f32e8b4f6b71af52a4eddce224526d04721a5L2-R5) [[2]](diffhunk://#diff-38a4649b8762af60abe388df6bbf8d652fd917602a989dbda55fe5863b18e4a4L2-R5) [[3]](diffhunk://#diff-fe5e5109d39d32153691e5a5279b514b8f7ed6928fde2dacf53f39edf7a27183L2-R5) [[4]](diffhunk://#diff-31f87b50174daab77e2a093f8c59ebd3cef5060a8d763edb27dac54d581e9f12L2-R5) [[5]](diffhunk://#diff-ea852184afd678f969d9bce5243ee299262c93679aaaae1cbe1f74f68764b765L2-R5)

**Improvements to test utility usage:**
* Changed the copy logic in `build.sh` to copy all files from `test/test-utils/` instead of just `test-utils.sh`, ensuring that the new helper script is available in the test environment.

**GitHub action configuration updates:**
* Added a description to the smoke test GitHub action for clarity.
* Removed the explicit checkout step from the smoke test GitHub action, streamlining the workflow.