### PR TITLE
Update Dockerfiles to use 'noble' tag for base images across all Azure Functions

### DIFF
--- a/src/azure-functions-dotnet/.devcontainer/Dockerfile
+++ b/src/azure-functions-dotnet/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/devcontainers/dotnet:${templateOption:dotnetVersion}
+FROM mcr.microsoft.com/devcontainers/dotnet:${templateOption:dotnetVersion}-noble

--- a/src/azure-functions-java/.devcontainer/Dockerfile
+++ b/src/azure-functions-java/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/devcontainers/base:ubuntu
+FROM mcr.microsoft.com/devcontainers/base:noble

--- a/src/azure-functions-node/.devcontainer/Dockerfile
+++ b/src/azure-functions-node/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/devcontainers/base:ubuntu
+FROM mcr.microsoft.com/devcontainers/base:noble

--- a/src/azure-functions-powershell/.devcontainer/Dockerfile
+++ b/src/azure-functions-powershell/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/devcontainers/dotnet:8.0
+FROM mcr.microsoft.com/devcontainers/dotnet:8.0-noble

--- a/src/azure-functions-python/.devcontainer/Dockerfile
+++ b/src/azure-functions-python/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM mcr.microsoft.com/devcontainers/base:ubuntu
+FROM mcr.microsoft.com/devcontainers/base:noble


### PR DESCRIPTION
This pull request updates the base images used in the devcontainer Dockerfiles for Azure Functions templates to use the Ubuntu 24.04 "Noble" release. This ensures all development containers are built on the latest long-term support (LTS) version of Ubuntu, providing updated packages and improved security.

**Devcontainer base image updates:**

* Updated the base image in `src/azure-functions-dotnet/.devcontainer/Dockerfile` to use the `-noble` tag, targeting Ubuntu 24.04 for .NET development containers.
* Updated the base image in `src/azure-functions-powershell/.devcontainer/Dockerfile` to use the `8.0-noble` tag for PowerShell development containers.
* Updated the base image in `src/azure-functions-java/.devcontainer/Dockerfile`, `src/azure-functions-node/.devcontainer/Dockerfile`, and `src/azure-functions-python/.devcontainer/Dockerfile` from `ubuntu` to `noble` for Java, Node.js, and Python development containers.